### PR TITLE
Comply to Nominatim Usage Policy

### DIFF
--- a/mqtt.py
+++ b/mqtt.py
@@ -69,7 +69,6 @@ def on_publish(client, userdata, mid):
                   *Entity.pending.pop(mid))
 
 
-@threadsafe
 def on_disconnect(client, userdata, rc):
     if rc == MQTT_ERR_SUCCESS:
         # we called disconnect ourselves

--- a/mqtt.py
+++ b/mqtt.py
@@ -477,7 +477,7 @@ def run(voc, config):
         pid=getpid()) if not clean_session else None
 
     mqtt_config = read_mqtt_config()
-    mqtt = paho.Client(client_id = client_id, clean_session = clean_session)
+    mqtt = paho.Client(client_id=client_id, clean_session=clean_session)
     mqtt.username_pw_set(username=mqtt_config['username'],
                          password=mqtt_config['password'])
     mqtt.tls_set(certs.where())

--- a/voc
+++ b/voc
@@ -56,7 +56,10 @@ def lookup_position(lat, lon):
         from geopy.geocoders import Nominatim
 
         geopy.geocoders.options.default_ssl_context = ssl.create_default_context(cafile=certifi.where())
+        geopy.geocoders.options.default_timeout = 10
+        geopy.geocoders.options.default_user_agent='volvooncall/%s' % __version__
         geolocator = Nominatim()
+        # geolocator = Nominatim(user_agent='volvooncall/%s' % __version__, timeout=10)
         return geolocator.reverse((lat, lon))
     except ImportError:
         _LOGGER.warning('geopy or certifi not installed. position lookup not available')


### PR DESCRIPTION
1) _geopy_: _Nominatim_ requires each application to provide their own custom user-agent.
Requests providing default agents as used by _geopy_ or _python_ are getting refused.
https://geopy.readthedocs.io/en/stable/#nominatim

2) Increase default-timeout for _geopy_-requests to 10s.

I decided to set these defaults globally in `geopy.options,` alternatively, they might be forward with nominatim's ctor only `geolocator = Nominatim(user_agent='volvooncall/%s' % __version__, timeout=10)`