### PR TITLE
voc: Fix [SSL: CERTIFICATE_VERIFY_FAILED] with aiohttp

### DIFF
--- a/voc
+++ b/voc
@@ -40,12 +40,14 @@ Options:
 import docopt
 import logging
 import asyncio
+import ssl
+import certifi
 from time import time
 from json import dumps as to_json
 from sys import stderr
 from collections import OrderedDict
 from datetime import timezone
-from aiohttp import ClientSession
+from aiohttp import ClientSession, TCPConnector
 from volvooncall import (
     __version__,
     read_credentials,
@@ -55,6 +57,7 @@ from volvooncall import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+_SSL_CONTEXT = ssl.create_default_context(cafile = certifi.where())
 
 LOGFMT = "%(asctime)s %(levelname)5s (%(threadName)s) [%(name)s] %(message)s"
 DATEFMT = "%y-%m-%d %H:%M.%S"
@@ -62,15 +65,13 @@ DATEFMT = "%y-%m-%d %H:%M.%S"
 
 def lookup_position(lat, lon):
     try:
-        import ssl
-        import certifi
         import geopy.geocoders
         from geopy.geocoders import Nominatim
 
         geolocator = Nominatim(
             user_agent="volvooncall/%s" % __version__,
             timeout=10,
-            ssl_context=ssl.create_default_context(cafile=certifi.where()),
+            ssl_context=_SSL_CONTEXT,
         )
         return geolocator.reverse((lat, lon))
     except ImportError:
@@ -140,7 +141,7 @@ async def main(args):
     if args["--immutable"] or "--immutable" not in credentials:
         credentials.update(immutable=args["--immutable"])
 
-    async with ClientSession() as session:
+    async with ClientSession(connector=TCPConnector(ssl=_SSL_CONTEXT)) as session:
 
         connection = Connection(session, **credentials)
 


### PR DESCRIPTION
voc: Create global _SSL_CONTEXT. 
Apply context to aiohttp.clientsession and geopy.
Python >=3.7 enforces certificate-validation for https.