### PR TITLE
include other location fields from voc, and use the received timestamp

### DIFF
--- a/volvooncall/dashboard.py
+++ b/volvooncall/dashboard.py
@@ -352,7 +352,7 @@ class Position(Instrument):
     @property
     def state(self):
         state = super().state or {}
-        return (state.get("latitude", "?"), state.get("longitude", "?"))
+        return (state.get("latitude", "?"), state.get("longitude", "?"), state.get("timestamp", None), state.get("speed", None), state.get("heading", None))
 
 
 #  FIXME: Maybe make this list configurable as external yaml

--- a/volvooncall/mqtt.py
+++ b/volvooncall/mqtt.py
@@ -135,7 +135,7 @@ class Entity:
         elif self.is_binary_sensor:
             return (STATE_OFF, STATE_ON)[state]
         elif self.is_position:
-            lat, lon = state
+            lat, lon, timestamp, speed, heading = state
             key = self.config.get(CONF_OWNTRACKS_KEY)
             res = dict(
                 _type="location",
@@ -145,7 +145,15 @@ class Entity:
                 lon=lon,
                 acc=1,
                 tst=int(time()),
+                now=int(time()),
             )
+            if timestamp is not None:
+                res['tst'] = int(timestamp.timestamp())
+                res['tst_iso'] = timestamp.isoformat()
+            if speed is not None:
+                res['speed'] = speed
+            if heading is not None:
+                res['heading'] = heading
             return (
                 dict(
                     _type="encrypted",


### PR DESCRIPTION
The json from voc has more location fields than just lat/lon.

    "position": {
        "longitude": -XXXXX,
        "latitude": -YYYYY,
        "timestamp": "2019-01-07T13:33:08+00:00",
        "speed": null,
        "heading": null
    },

it also provides the location timestamp. The mqtt is publishing with the current timestamp.
This change publishes the real location timestamp and the other fields if available.

If someone still wants the publishing timestamp it will be in "now" field.

