### PR TITLE
add prometheus metric output

### DIFF
--- a/voc
+++ b/voc
@@ -11,6 +11,7 @@ Usage:
   voc [-v|-vv] [options] trips [(--pretty|--json|--csv)]
   voc [-v|-vv] [options] owntracks
   voc [-v|-vv] [options] print [<attribute>]
+  voc [-v|-vv] [options] prometheus <filename>
   voc [-v|-vv] [options] (lock | unlock)
   voc [-v|-vv] [options] heater (start | stop)
   voc [-v|-vv] [options] engine (start | stop)
@@ -48,7 +49,8 @@ from datetime import timezone
 import ssl
 import certifi
 from aiohttp import ClientSession, TCPConnector
-from volvooncall import __version__, Connection
+from volvooncall import __version__, Connection, prometheus
+from volvooncall.prometheus import PrometheusFile
 from volvooncall.util import read_config, json_serialize, owntracks_encrypt
 
 _LOGGER = logging.getLogger(__name__)
@@ -150,6 +152,19 @@ async def main(args):
 
         journal = args["trips"] or args["dashboard"] or args["mqtt"]
         res = await connection.update(journal=journal)
+
+        if args["prometheus"]:
+            with PrometheusFile(args["<filename>"]) as f:
+                f.write("# HELP voc_up Status if scraping was successful.\n")
+                f.write("# TYPE voc_up gauge\n")
+                if not res:
+                    f.write("voc_up 0\n")
+                else:
+                    f.write("voc_up 1\n")
+                    f.write("\n")
+
+                    prometheus.write_metrics(f, connection.vehicles)
+            exit()
 
         if not res:
             exit("Could not connect to the server.")

--- a/volvooncall/prometheus.py
+++ b/volvooncall/prometheus.py
@@ -52,7 +52,6 @@ def write_metrics(file, vehicles):
 
     file.write("# HELP trip_meter trip meters (in meter) differentiated by type\n")
     file.write("# TYPE trip_meter counter\n")
-    print(vehicles)
     vehicles, vehicles_copy = itertools.tee(vehicles)
     file.write("\n".join(format_metric(vehicles_copy, 'tripMeter1', 'trip_meter', {'type': 'TM'})))
     file.write("\n")

--- a/volvooncall/prometheus.py
+++ b/volvooncall/prometheus.py
@@ -31,21 +31,15 @@ def format_metric(vehicles, metric, metric_alias=None, additional_labels=None):
 
         attrs_list = ['{key}="{value}"'.format(key=key, value=value) for key, value in attrs.items()]
 
-        timestamp_attr = '{}Timestamp'.format(metric)
-        timestamp_value = ''
-        if vehicle.has_attr(timestamp_attr):
-            timestamp_value = int(vehicle.get_attr(timestamp_attr).timestamp() * 1000)
-
         value = vehicle.get_attr(metric)
         if isinstance(value, bool):
             if value:
                 value = 1
             else:
                 value = 0
-        yield "{metric}{{{attrs}}} {value} {timestamp}".format(metric=metric if metric_alias is None else metric_alias,
-                                                               attrs=','.join(attrs_list),
-                                                               value=value,
-                                                               timestamp=timestamp_value)
+        yield "{metric}{{{attrs}}} {value}".format(metric=metric if metric_alias is None else metric_alias,
+                                                   attrs=','.join(attrs_list),
+                                                   value=value)
 
 
 def write_metrics(file, vehicles):

--- a/volvooncall/prometheus.py
+++ b/volvooncall/prometheus.py
@@ -1,0 +1,97 @@
+import os
+
+
+class PrometheusFile:
+
+    def __init__(self, file):
+        self.filename = file
+        self.tempfile = file + ".temp"
+
+    def __enter__(self):
+        self.file = open(self.tempfile, mode='w+')
+        print("enter")
+        return self.file.__enter__()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.file.__exit__(exc_type, exc_val, exc_tb)
+        os.rename(self.tempfile, self.filename)
+        print("exit", exc_type, exc_val, exc_tb)
+
+
+def format_metric(vehicles, metric, metric_alias=None, additional_labels=None):
+    if additional_labels is None:
+        additional_labels = {}
+    for vehicle in vehicles:
+        attrs = {
+            "vin": vehicle.vin,
+            "registration": vehicle.registration_number,
+            "model": vehicle.vehicle_type,
+            "modelyear": vehicle.model_year
+        }
+        attrs.update(additional_labels)
+
+        attrs_list = ['{key}="{value}"'.format(key=key, value=value) for key, value in attrs.items()]
+
+        timestamp_attr = '{}Timestamp'.format(metric)
+        timestamp_value = ''
+        if vehicle.has_attr(timestamp_attr):
+            timestamp_value = int(vehicle.get_attr(timestamp_attr).timestamp() * 1000)
+
+        value = vehicle.get_attr(metric)
+        if isinstance(value, bool):
+            if value:
+                value = 1
+            else:
+                value = 0
+
+        yield "{metric}{{{attrs}}} {value} {timestamp}".format(metric=metric if metric_alias is None else metric_alias,
+                                                               attrs=','.join(attrs_list),
+                                                               value=value,
+                                                               timestamp=timestamp_value)
+
+
+def write_metrics(file, vehicles):
+    file.write("# HELP odometer Vehicle main odometer in meter.\n")
+    file.write("# TYPE odometer counter\n")
+    file.write("\n".join(format_metric(vehicles, 'odometer')))
+    file.write("\n")
+
+    file.write("# HELP trip_meter trip meters (in meter) differentiated by type\n")
+    file.write("# TYPE trip_meter counter\n")
+    file.write("\n".join(format_metric(vehicles, 'tripMeter1', 'trip_meter', {'type': 'TM'})))
+    file.write("\n")
+    file.write("\n".join(format_metric(vehicles, 'tripMeter2', 'trip_meter', {'type': 'TA'})))
+
+    file.write("# HELP fuel_amount tank size and current volume in liters\n")
+    file.write("# TYPE fuel_amount gauge\n")
+    file.write("\n".join(format_metric(vehicles, 'fuelTankVolume', 'fuel_amount', {'type': 'capacity'})))
+    file.write("\n")
+    file.write("\n".join(format_metric(vehicles, 'fuelAmount', 'fuel_amount', {'type': 'level'})))
+    file.write("\n")
+
+    file.write("# HELP fuel_level tank level in percent\n")
+    file.write("# TYPE fuel_level gauge\n")
+    file.write("\n".join(format_metric(vehicles, 'fuelAmountLevel', 'fuel_level')))
+    file.write("\n")
+
+    file.write("# HELP car_status car status metrics\n")
+    file.write("# TYPE car_status gauge\n")
+    file.write("\n".join(format_metric(vehicles, 'engineRunning', 'car_status', {'type': 'engineRunning'})))
+    file.write("\n")
+    file.write("\n".join(format_metric(vehicles, 'carLocked', 'car_status', {'type': 'carLocked'})))
+    file.write("\n")
+
+    file.write("# HELP distance distance values\n")
+    file.write("# TYPE distance gauge\n")
+    file.write("\n".join(format_metric(vehicles, 'distanceToEmpty', 'distance', {'type': 'toEmpty'})))
+    file.write("\n")
+
+    file.write("# HELP consumption consumption values\n")
+    file.write("# TYPE consumption gauge\n")
+    file.write("\n".join(format_metric(vehicles, 'averageFuelConsumption', 'consumption', {'type': 'fuel'})))
+    file.write("\n")
+
+    file.write("# HELP speed speed values\n")
+    file.write("# TYPE speed gauge\n")
+    file.write("\n".join(format_metric(vehicles, 'averageSpeed', 'speed', {'type': 'average'})))
+    file.write("\n")

--- a/volvooncall/prometheus.py
+++ b/volvooncall/prometheus.py
@@ -1,3 +1,4 @@
+import itertools
 import os
 
 
@@ -9,13 +10,11 @@ class PrometheusFile:
 
     def __enter__(self):
         self.file = open(self.tempfile, mode='w+')
-        print("enter")
         return self.file.__enter__()
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.file.__exit__(exc_type, exc_val, exc_tb)
         os.rename(self.tempfile, self.filename)
-        print("exit", exc_type, exc_val, exc_tb)
 
 
 def format_metric(vehicles, metric, metric_alias=None, additional_labels=None):
@@ -43,7 +42,6 @@ def format_metric(vehicles, metric, metric_alias=None, additional_labels=None):
                 value = 1
             else:
                 value = 0
-
         yield "{metric}{{{attrs}}} {value} {timestamp}".format(metric=metric if metric_alias is None else metric_alias,
                                                                attrs=','.join(attrs_list),
                                                                value=value,
@@ -51,47 +49,61 @@ def format_metric(vehicles, metric, metric_alias=None, additional_labels=None):
 
 
 def write_metrics(file, vehicles):
+
     file.write("# HELP odometer Vehicle main odometer in meter.\n")
     file.write("# TYPE odometer counter\n")
-    file.write("\n".join(format_metric(vehicles, 'odometer')))
-    file.write("\n")
+    vehicles, vehicles_copy = itertools.tee(vehicles)
+    file.write("\n".join(format_metric(vehicles_copy, 'odometer')))
+    file.write("\n\n")
 
     file.write("# HELP trip_meter trip meters (in meter) differentiated by type\n")
     file.write("# TYPE trip_meter counter\n")
-    file.write("\n".join(format_metric(vehicles, 'tripMeter1', 'trip_meter', {'type': 'TM'})))
+    print(vehicles)
+    vehicles, vehicles_copy = itertools.tee(vehicles)
+    file.write("\n".join(format_metric(vehicles_copy, 'tripMeter1', 'trip_meter', {'type': 'TM'})))
     file.write("\n")
-    file.write("\n".join(format_metric(vehicles, 'tripMeter2', 'trip_meter', {'type': 'TA'})))
+    vehicles, vehicles_copy = itertools.tee(vehicles)
+    file.write("\n".join(format_metric(vehicles_copy, 'tripMeter2', 'trip_meter', {'type': 'TA'})))
+    file.write("\n\n")
 
     file.write("# HELP fuel_amount tank size and current volume in liters\n")
     file.write("# TYPE fuel_amount gauge\n")
-    file.write("\n".join(format_metric(vehicles, 'fuelTankVolume', 'fuel_amount', {'type': 'capacity'})))
+    vehicles, vehicles_copy = itertools.tee(vehicles)
+    file.write("\n".join(format_metric(vehicles_copy, 'fuelTankVolume', 'fuel_amount', {'type': 'capacity'})))
     file.write("\n")
-    file.write("\n".join(format_metric(vehicles, 'fuelAmount', 'fuel_amount', {'type': 'level'})))
-    file.write("\n")
+    vehicles, vehicles_copy = itertools.tee(vehicles)
+    file.write("\n".join(format_metric(vehicles_copy, 'fuelAmount', 'fuel_amount', {'type': 'level'})))
+    file.write("\n\n")
 
     file.write("# HELP fuel_level tank level in percent\n")
     file.write("# TYPE fuel_level gauge\n")
-    file.write("\n".join(format_metric(vehicles, 'fuelAmountLevel', 'fuel_level')))
-    file.write("\n")
+    vehicles, vehicles_copy = itertools.tee(vehicles)
+    file.write("\n".join(format_metric(vehicles_copy, 'fuelAmountLevel', 'fuel_level')))
+    file.write("\n\n")
 
     file.write("# HELP car_status car status metrics\n")
     file.write("# TYPE car_status gauge\n")
-    file.write("\n".join(format_metric(vehicles, 'engineRunning', 'car_status', {'type': 'engineRunning'})))
+    vehicles, vehicles_copy = itertools.tee(vehicles)
+    file.write("\n".join(format_metric(vehicles_copy, 'engineRunning', 'car_status', {'type': 'engineRunning'})))
     file.write("\n")
-    file.write("\n".join(format_metric(vehicles, 'carLocked', 'car_status', {'type': 'carLocked'})))
-    file.write("\n")
+    vehicles, vehicles_copy = itertools.tee(vehicles)
+    file.write("\n".join(format_metric(vehicles_copy, 'carLocked', 'car_status', {'type': 'carLocked'})))
+    file.write("\n\n")
 
     file.write("# HELP distance distance values\n")
     file.write("# TYPE distance gauge\n")
-    file.write("\n".join(format_metric(vehicles, 'distanceToEmpty', 'distance', {'type': 'toEmpty'})))
-    file.write("\n")
+    vehicles, vehicles_copy = itertools.tee(vehicles)
+    file.write("\n".join(format_metric(vehicles_copy, 'distanceToEmpty', 'distance', {'type': 'toEmpty'})))
+    file.write("\n\n")
 
     file.write("# HELP consumption consumption values\n")
     file.write("# TYPE consumption gauge\n")
-    file.write("\n".join(format_metric(vehicles, 'averageFuelConsumption', 'consumption', {'type': 'fuel'})))
-    file.write("\n")
+    vehicles, vehicles_copy = itertools.tee(vehicles)
+    file.write("\n".join(format_metric(vehicles_copy, 'averageFuelConsumption', 'consumption', {'type': 'fuel'})))
+    file.write("\n\n")
 
     file.write("# HELP speed speed values\n")
     file.write("# TYPE speed gauge\n")
-    file.write("\n".join(format_metric(vehicles, 'averageSpeed', 'speed', {'type': 'average'})))
-    file.write("\n")
+    vehicles, vehicles_copy = itertools.tee(vehicles)
+    file.write("\n".join(format_metric(vehicles_copy, 'averageSpeed', 'speed', {'type': 'average'})))
+    file.write("\n\n")


### PR DESCRIPTION
allows writing out prometheus metrics ready to be scraped by the textfile collector (part of node exporter)