### PR TITLE
Update license tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     version="0.8.12",
     description="Communicate with VOC",
     url="https://github.com/molobrakos/volvooncall",
-    license="",
+    license="Unlicense",
     author="Erik",
     author_email="error.errorsson@gmail.com",
     scripts=["voc"],


### PR DESCRIPTION
This allows third-party tools like Pypi or `pyp2rpm` to get the license details.