### PR TITLE
Separate charging vs plugged in

### DIFF
--- a/volvooncall/dashboard.py
+++ b/volvooncall/dashboard.py
@@ -260,6 +260,7 @@ class BatteryChargeStatus(BinarySensor):
     def state(self):
         return super(BinarySensor, self).state.endswith("_Charging")
 
+
 class PluggedInStatus(BinarySensor):
     def __init__(self):
         super().__init__(


### PR DESCRIPTION
VOC provides information on whether the car is plugged in as well as whether it's charging. This PR updates the HA dashboard logic to expose each as a separate `binary_sensor`.