### PR TITLE
Ensure unique slug for plugged-in status

### DIFF
--- a/volvooncall/dashboard.py
+++ b/volvooncall/dashboard.py
@@ -258,7 +258,6 @@ class BatteryChargeStatus(BinarySensor):
             "hvBattery.hvBatteryChargeStatusDerived",
             "Battery charging",
             "battery_charging",
-            slug_override="battery_charging"
         )
 
     @property

--- a/volvooncall/dashboard.py
+++ b/volvooncall/dashboard.py
@@ -214,7 +214,12 @@ class JournalLastTrip(Sensor):
 
 class BinarySensor(Instrument):
     def __init__(self, attr, name, device_class, slug_override=None):
-        super().__init__(component="binary_sensor", attr=attr, name=name, slug_override=slug_override)
+        super().__init__(
+            component="binary_sensor",
+            attr=attr,
+            name=name,
+            slug_override=slug_override,
+        )
         self.device_class = device_class
 
     @property
@@ -271,7 +276,7 @@ class PluggedInStatus(BinarySensor):
             "hvBattery.hvBatteryChargeStatusDerived",
             "Plug status",
             "plug",
-            slug_override="plugged_in_status"
+            slug_override="plugged_in_status",
         )
 
     @property

--- a/volvooncall/dashboard.py
+++ b/volvooncall/dashboard.py
@@ -27,7 +27,10 @@ class Instrument:
 
     @property
     def slug_attr(self):
-        return self.slug_override if self.slug_override is not None else camel2slug(self.attr.replace(".", "_"))
+        if self.slug_override is not None:
+            return self.slug_override
+        else:
+            return camel2slug(self.attr.replace(".", "_"))
 
     def setup(self, vehicle, mutable=True, **config):
         self.vehicle = vehicle
@@ -255,7 +258,6 @@ class BatteryChargeStatus(BinarySensor):
             "hvBattery.hvBatteryChargeStatusDerived",
             "Battery charging",
             "battery_charging",
-            slug_override="battery_charging"
         )
 
     @property

--- a/volvooncall/dashboard.py
+++ b/volvooncall/dashboard.py
@@ -255,6 +255,7 @@ class BatteryChargeStatus(BinarySensor):
             "hvBattery.hvBatteryChargeStatusDerived",
             "Battery charging",
             "battery_charging",
+            slug_override="battery_charging"
         )
 
     @property

--- a/volvooncall/dashboard.py
+++ b/volvooncall/dashboard.py
@@ -258,6 +258,7 @@ class BatteryChargeStatus(BinarySensor):
             "hvBattery.hvBatteryChargeStatusDerived",
             "Battery charging",
             "battery_charging",
+            slug_override="battery_charging"
         )
 
     @property

--- a/volvooncall/dashboard.py
+++ b/volvooncall/dashboard.py
@@ -11,12 +11,13 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class Instrument:
-    def __init__(self, component, attr, name, icon=None):
+    def __init__(self, component, attr, name, icon=None, slug_override=None):
         self.attr = attr
         self.component = component
         self.name = name
         self.vehicle = None
         self.icon = icon
+        self.slug_override = slug_override
 
     def __repr__(self):
         return self.full_name
@@ -26,7 +27,7 @@ class Instrument:
 
     @property
     def slug_attr(self):
-        return camel2slug(self.attr.replace(".", "_"))
+        return self.slug_override if self.slug_override is not None else camel2slug(self.attr.replace(".", "_"))
 
     def setup(self, vehicle, mutable=True, **config):
         self.vehicle = vehicle
@@ -209,8 +210,8 @@ class JournalLastTrip(Sensor):
 
 
 class BinarySensor(Instrument):
-    def __init__(self, attr, name, device_class):
-        super().__init__(component="binary_sensor", attr=attr, name=name)
+    def __init__(self, attr, name, device_class, slug_override=None):
+        super().__init__(component="binary_sensor", attr=attr, name=name, slug_override=slug_override)
         self.device_class = device_class
 
     @property
@@ -267,6 +268,7 @@ class PluggedInStatus(BinarySensor):
             "hvBattery.hvBatteryChargeStatusDerived",
             "Plug status",
             "plug",
+            slug_override="plugged_in_status"
         )
 
     @property


### PR DESCRIPTION
The "plugged-in status" and "battery charging" sensors pull from the same underlying attribute, so we need to ensure that they can generate unique slugs. This change allows an override slug per instrument as needed. My upcoming PR to Home Assistant will use this to properly disambiguate the two sensors.