### PR TITLE
requirements.txt: aiohttp: downgrade to version < 4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ amqtt>=0.10.0,<0.11.0
 certifi
 geopy>=1.14.0
 docopt
+

--- a/volvooncall/volvooncall.py
+++ b/volvooncall/volvooncall.py
@@ -79,7 +79,9 @@ class Connection:
                 return res
         except Exception as error:
             _LOGGER.warning(
-                "Failure when communicating with the server: %s", error, exc_info=True
+                "Failure when communicating with the server: %s",
+                error,
+                exc_info=True,
             )
             raise
 


### PR DESCRIPTION
Workaround for dependency-side issue in aiohttp 4.0.0a1 with py3.8 | py3.9
aiohttp < 4.0.0.a1 seems to be unaffected.
```
aiohttp-4.0.0a1-py3.9-linux-x86_64.egg/aiohttp/client.py:977: RuntimeWarning: coroutine 'noop' was never awaited
  self._resp.release()
```

Signed-off-by: umgfoin <umgfoin@users.noreply.github.com>